### PR TITLE
Rename sort-ram to sort-max-ram for clarity, add server_spread check

### DIFF
--- a/lib/algorithms/sort-max-ram.js
+++ b/lib/algorithms/sort-max-ram.js
@@ -16,6 +16,10 @@
 function
 sortUnreservedRam(log, state, servers)
 {
+	if ((constraints.pkg.alloc_server_spread ||
+	    constraints.defaults.server_spread) !== 'max-ram')
+		return ([servers]);
+
 	/* shallow copy to avoid mutating order of referred array */
 	servers = servers.slice(0);
 

--- a/lib/allocator.js
+++ b/lib/allocator.js
@@ -93,6 +93,7 @@ var DEFAULT_DESC = [
 		],
 		'soft-filter-locality-hints',
 		'sort-min-ram',
+		'sort-max-ram',
 		'sort-min-owner',
 		'sort-random',
 		'pick-weighted-random'

--- a/test/algorithms/sort-max-ram.test.js
+++ b/test/algorithms/sort-max-ram.test.js
@@ -8,7 +8,7 @@
  * Copyright (c) 2014, Joyent, Inc.
  */
 
-var sorter = require('../../lib/algorithms/sort-ram.js');
+var sorter = require('../../lib/algorithms/sort-max-ram.js');
 
 var log = {
 	trace: function () { return (true); },
@@ -30,7 +30,7 @@ function (t) {
 	];
 
 	var state = {};
-	var constraints = {};
+	var constraints = { pkg: { alloc_server_spread: 'max-ram' } };
 
 	var results = sorter.run(log, state, givenServers, constraints);
 	var sortedServers = results[0];


### PR DESCRIPTION
This goes together with a matching change to sdc-cnapi to add sort-max-ram to the default description.

If you have a relatively small cluster, or a cluster that is a set size and will take a long time to fill up, you may want to use 'emptiest server first' as your fill policy rather than the default behaviour of filling holes in wherever possible. This spreads the load out better when you know you're not going to fully utilize machines most of the time.

After these changes you can set the server_spread parameter to 'max-ram' with CNAPI to change to this policy.

(cc @trentm, from our IRC discussion the other day)