### PR TITLE
TRITON-2029 dapi allocator test needs to include hard-filter-zpool-encryption

### DIFF
--- a/lib/algorithms/hard-filter-zpool-encryption.js
+++ b/lib/algorithms/hard-filter-zpool-encryption.js
@@ -46,7 +46,7 @@ function filterZpoolEncryption(servers, opts, cb) {
 			reasons[server.uuid] = 'Server is Zpool Encrypted';
 		}
 
-		return encrypt ? zpoolEncrypted : !zpoolEncrypted;
+		return (encrypt ? zpoolEncrypted : !zpoolEncrypted);
 	});
 
 	cb(null, adequateServers, reasons);

--- a/test/allocator.test.js
+++ b/test/allocator.test.js
@@ -817,6 +817,7 @@ test('load available algorithms', function (t) {
 		'hard-filter-vlans',
 		'hard-filter-vm-count',
 		'hard-filter-volumes-from',
+		'hard-filter-zpool-encryption',
 		'identity',
 		'load-server-vms',
 		'override-overprovisioning',


### PR DESCRIPTION
Also fixed a `make check` warning.