### PR TITLE
TRITON-2033 volapi v2 support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -314,6 +314,7 @@ Some default values can be altered upon allocator initialisation.
 | filter_docker_min_platform        | String  | -     | Minimum platform version allowed for Docker containers.         |
 | filter_docker_nfs_volumes_automount_min_platform      | String  | -     | Minimum platform version allowed for Docker containers that automatically mount NFS volumes. |
 | filter_non_docker_nfs_volumes_automount_min_platform  | String  | -     | Minimum platform version allowed for non-Docker (infrastructure) containers that automatically mount NFS volumes. |
+| filter_volapi_nfs_v2_min_platform  | String  | -     | Minimum platform version allowed for volapi NFS v2 containers. These containers use the native NGZ (non global zone) NFS. |
 | filter_flexible_disk_min_platform   | String  | -     | Minimum platform version allowed for VMs that have flexible disk sizing. |
 | filter_headnode          | Boolean  | true    | Whether to remove the headnode from consideration for a new VM.       |
 | filter_min_resources     | Boolean  | true    | Whether to filter out CNs which don't have enough space for a new VM. |

--- a/lib/algorithms/hard-filter-feature-min-platform.js
+++ b/lib/algorithms/hard-filter-feature-min-platform.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*

--- a/lib/algorithms/hard-filter-feature-min-platform.js
+++ b/lib/algorithms/hard-filter-feature-min-platform.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*
@@ -20,6 +20,9 @@
  *
  * - "non-docker automatic volume mounting", or the ability to have an
  *   infrastructure container automatically mount the volumes it depends on
+ *
+ * - "volapi nfs v2" feature, where volapi nfs version 2 zones require a
+ *   min_platform that includes the NGZ (non-global zone) zfs/NFS support.
  *
  * - "flexible disk size" feature, or the ability to have several zvols attached
  *   and/or destroyed on a bhyve container
@@ -42,6 +45,7 @@ function filterFeatureMinPlatform(servers, opts, cb) {
 	assert.object(opts.defaults, 'opts.defaults');
 	assert.func(cb, 'cb');
 
+	var minPlatforms;
 	var reasons = {};
 
 	var dkrMinPlatform = opts.defaults.filter_docker_min_platform;
@@ -75,6 +79,15 @@ function filterFeatureMinPlatform(servers, opts, cb) {
 			filterMinPlatforms(nonDkrVolAutomountMinPlatforms,
 				servers, 'Non-docker volume automount support',
 				reasons);
+	}
+
+	var nfsVolumeV2MinPlatform =
+		opts.defaults.filter_volapi_nfs_v2_min_platform;
+	if (nfsVolumeV2MinPlatform && opts.vm.internal_metadata &&
+			opts.vm.internal_metadata['volapi-nfs-version'] === 2) {
+		minPlatforms = { '7.0': nfsVolumeV2MinPlatform };
+		servers = filterMinPlatforms(minPlatforms, servers,
+			'volapi nfs v2 support', reasons);
 	}
 
 	var flexibleDiskMinPlatform =

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dapi",
   "description": "SmartDataCenter Designation API",
-  "version": "8.9.0",
+  "version": "8.10.0",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {

--- a/test/algorithms/hard-filter-min-platform-feature.test.js
+++ b/test/algorithms/hard-filter-min-platform-feature.test.js
@@ -61,6 +61,17 @@ var infraContainersNfsAutomountTestServers = common.genServers([
 	['b4343a95-5aeb-499a-bc0e-701c5119b89e', '7.0', '20170925T211846Z']
 ]);
 
+var infraContainersVolapiNfsV2TestServers = common.genServers([
+	['5d4de22f-e082-43ae-83ec-9957be55f2e1', null,  '20130129T122401Z'],
+	['eef1a665-5d51-4a6e-94cb-c23a8e11cc09', '6.5', '20130229T122401Z'],
+	['9728b8c3-ecbd-4af9-94b0-a1b26e6e5cc0', '7.0', '20121210T203034Z'],
+	['c98b17b0-d4f9-4a93-b4da-85ee6a065f8a', '7.0', '20130129T122401Z'],
+	['59359918-cb06-45c2-9adb-42fc814baa0d', '7.0', '20191213T123039Z'],
+	['b4343a95-5aeb-499a-bc0e-701c5119b89e', '7.0', '20200925T211846Z'],
+	['9902bee1-fe4a-4f77-93db-951ed5c501bb', '7.1', '20121218T203452Z'],
+	['26dbdcdc-ed50-4169-b27f-e12f27c20026', '7.1', '20200129T122401Z']
+]);
+
 var infraContainersFlexibleDiskTestServers = common.genServers([
 	/* null should default to 6.5 */
 	['e69c5420-3876-11e9-9081-c749e75a2f97', null,  '20130129T122401Z'],
@@ -292,6 +303,61 @@ test('filterFeatureMinPlatform with ' +
 	};
 
 	checkFilter(t, infraContainersNfsAutomountTestServers, opts,
+		expectedServers, expectedReasons);
+});
+
+
+test('filterFeatureMinPlatform for filter_volapi_nfs_v2_min_platform, ' +
+		'VM requires volapi_nfs_v2',
+		function (t) {
+
+	var minPlatform = '20191201T000000Z';
+	var expectedReasons = {
+		/* BEGIN JSSTYLED */
+		'5d4de22f-e082-43ae-83ec-9957be55f2e1': 'volapi nfs v2 support requires min platforms {"7.0":"' + minPlatform + '"}, but server has {"6.5":"20130129T122401Z"}',
+		'eef1a665-5d51-4a6e-94cb-c23a8e11cc09': 'volapi nfs v2 support requires min platforms {"7.0":"' + minPlatform + '"}, but server has {"6.5":"20130229T122401Z"}',
+		'9728b8c3-ecbd-4af9-94b0-a1b26e6e5cc0': 'volapi nfs v2 support requires min platforms {"7.0":"' + minPlatform + '"}, but server has {"7.0":"20121210T203034Z"}',
+		'c98b17b0-d4f9-4a93-b4da-85ee6a065f8a': 'volapi nfs v2 support requires min platforms {"7.0":"' + minPlatform + '"}, but server has {"7.0":"20130129T122401Z"}'
+		/* END JSSTYLED */
+	};
+	var expectedServers = infraContainersVolapiNfsV2TestServers.slice(4);
+
+	var opts = {
+		vm: {
+			internal_metadata: {
+				'volapi-nfs-version': 2
+			}
+		},
+		img: {},
+		pkg: {},
+		defaults: {
+			filter_volapi_nfs_v2_min_platform: minPlatform
+		}
+	};
+
+	checkFilter(t, infraContainersVolapiNfsV2TestServers, opts,
+		expectedServers, expectedReasons);
+});
+
+
+test('filterFeatureMinPlatform with filter_volapi_nfs_v2_min_platform, ' +
+		'VM does not require volapi_nfs_v2',
+		function (t) {
+
+	var expectedReasons = {};
+	var expectedServers = infraContainersVolapiNfsV2TestServers;
+	var minPlatform = '20191201T000000Z';
+
+	var opts = {
+		vm: {},
+		img: {},
+		pkg: {},
+		defaults: {
+			filter_volapi_nfs_v2_min_platform: minPlatform
+		}
+	};
+
+	checkFilter(t, infraContainersVolapiNfsV2TestServers, opts,
 		expectedServers, expectedReasons);
 });
 


### PR DESCRIPTION
This allows CNAPI to set the minimum platform version that provides the NFS v2 support.